### PR TITLE
added error handling for login page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,9 @@
 closes (insert issue)
 
 # How does it do this?
+
+## Tournament API
+
+## Tounament Registration App
+
+## Tournament Admin Dashboard

--- a/tournament-admin-v2/app/root.tsx
+++ b/tournament-admin-v2/app/root.tsx
@@ -42,7 +42,7 @@ export default function App() {
                 </button>
               </Form>
             </div>
-            <div className="container mx-auto mt-2 max-w-6xl">
+            <div className="container mx-5 mt-2 max-w-6xl">
               <Outlet />
             </div>
           </>

--- a/tournament-admin-v2/app/routes/login.tsx
+++ b/tournament-admin-v2/app/routes/login.tsx
@@ -2,12 +2,13 @@ import {
   ActionFunctionArgs,
   LoaderFunction,
   createCookie,
+  json,
   redirect,
 } from "@remix-run/node";
-import { Form, useNavigation } from "@remix-run/react";
+import { Form, useActionData, useNavigation } from "@remix-run/react";
 import { Card, PageTitle } from "~/components";
 import { tokenCookie } from "~/cookies.server";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 
 export const loader: LoaderFunction = async ({ request }) => {
   const cookieHeader = request.headers.get("Cookie");
@@ -20,9 +21,17 @@ export const loader: LoaderFunction = async ({ request }) => {
 
 export default function Index() {
   const navigation = useNavigation();
+  const actionData = useActionData<{ message: string }>();
+
+  console.log(actionData);
 
   return (
     <div className="flex justify-center items-center h-screen w-screen flex-col space-y-5">
+      {actionData && (
+        <div className="bg-red-500 outline outline-red-600 outline-offset-2 px-7 py-5 rounded-lg">
+          <p>An error occured: {actionData.message}</p>
+        </div>
+      )}
       <PageTitle>Login</PageTitle>
       <Card>
         <Form method="post" action="/login">
@@ -58,13 +67,23 @@ export default function Index() {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const body = Object.fromEntries(await request.formData());
-  const response = await axios.post(`${process.env.API_URL}/login`, body);
-  if (response.data.token) {
-    const cookie = { token: response.data.token };
-    return redirect("/", {
-      headers: { "Set-Cookie": await tokenCookie.serialize(cookie) },
-    });
+  try {
+    const body = Object.fromEntries(await request.formData());
+    const response = await axios.post(`${process.env.API_URL}/login`, body);
+    if (response.data.token) {
+      const cookie = { token: response.data.token };
+      return redirect("/", {
+        headers: { "Set-Cookie": await tokenCookie.serialize(cookie) },
+      });
+    }
+    return redirect("/login");
+  } catch (error: any) {
+    if (error.response) {
+      return json({ message: error.response.data.message }, { status: 400 });
+    }
+    return json(
+      { message: "We don't know what though. We will investigate" },
+      { status: 500 }
+    );
   }
-  return redirect("/login");
 }


### PR DESCRIPTION
# Description of PR

closes #15 
Adds an error banner for login page surfacing errors

# How does it do this?

## Tournament Admin
Uses actionData hook to get a response if an error occurs, and displays it as a banner above the login card