### PR TITLE
Attachments section

### DIFF
--- a/tournament-admin-v2/app/routes/participant.$id.attachments.$key.tsx
+++ b/tournament-admin-v2/app/routes/participant.$id.attachments.$key.tsx
@@ -1,0 +1,38 @@
+import { LoaderFunction, json } from "@remix-run/node";
+import { useLoaderData, useParams } from "@remix-run/react";
+import axios from "axios";
+import { tokenCookie } from "~/cookies.server";
+
+export const loader: LoaderFunction = async ({ request, params }) => {
+  const { key } = params;
+
+  const cookie = await tokenCookie.parse(request.headers.get("Cookie"));
+
+  const { data } = await axios.get(`${process.env.API_URL}/image/${key}`, {
+    headers: { Authorization: `Bearer ${cookie.token}` },
+  });
+  return json(data);
+};
+
+export default function Index() {
+  const { key } = useParams();
+  const data = useLoaderData<any>();
+
+  const getType = () => {
+    return key?.split(".")[1];
+  };
+
+  console.log(getType());
+
+  return (
+    <div className="flex justify-center items-center h-full">
+      {getType() === "pdf" ? (
+        <object data={data} type="application/pdf" width={700} height={900}>
+          <embed src={data} type="application/pdf" />
+        </object>
+      ) : (
+        <img src={data} alt={key} className="w-1/3" />
+      )}
+    </div>
+  );
+}

--- a/tournament-admin-v2/app/routes/participant.$id.attachments.tsx
+++ b/tournament-admin-v2/app/routes/participant.$id.attachments.tsx
@@ -1,0 +1,63 @@
+import { isRouteErrorResponse, useRouteError } from "@remix-run/react";
+import * as ScrollArea from "@radix-ui/react-scroll-area";
+
+export default function Index() {
+  console.log("test");
+
+  const tags = Array.from({ length: 50 }).map(
+    (_, i, a) => `v1.2.0-beta.${a.length - i}`
+  );
+
+  return (
+    <div className="space-y-1">
+      <p className="text-2xl font-bold">Attachments</p>
+      <div>
+        <ScrollArea.Root className="w-1/4 h-52">
+          <ScrollArea.Viewport className="h-full w-full">
+            {tags.map((v, i) => (
+              <div
+                key={i}
+                className="bg-slate-800 my-2 rounded text-lg p-2 hover:bg-slate-700"
+              >
+                {v}
+              </div>
+            ))}
+          </ScrollArea.Viewport>
+          <ScrollArea.Scrollbar
+            className="flex select-none touch-none p-0.5 bg-blackA3 transition-colors duration-[160ms] ease-out hover:bg-blackA5 data-[orientation=vertical]:w-2.5 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:h-2.5"
+            orientation="vertical"
+          >
+            <ScrollArea.Thumb className="flex-1 bg-mauve10 rounded-[10px] relative before:content-[''] before:absolute before:top-1/2 before:left-1/2 before:-translate-x-1/2 before:-translate-y-1/2 before:w-full before:h-full before:min-w-[44px] before:min-h-[44px]" />
+          </ScrollArea.Scrollbar>
+          <ScrollArea.Corner className="bg-black-50" />
+        </ScrollArea.Root>
+      </div>
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <div>
+        <h1>
+          {error.status} {error.statusText}
+        </h1>
+        <p>{error.data}</p>
+      </div>
+    );
+  } else if (error instanceof Error) {
+    return (
+      <div>
+        <h1>Error</h1>
+        <p>{error.message}</p>
+        <p>The stack trace is:</p>
+        <pre>{error.stack}</pre>
+      </div>
+    );
+  } else {
+    return <h1>Unknown Error</h1>;
+  }
+}

--- a/tournament-admin-v2/app/routes/participant.$id.attachments.tsx
+++ b/tournament-admin-v2/app/routes/participant.$id.attachments.tsx
@@ -1,6 +1,9 @@
 import {
+  Link,
+  Outlet,
   isRouteErrorResponse,
   useLoaderData,
+  useLocation,
   useRouteError,
 } from "@remix-run/react";
 import * as ScrollArea from "@radix-ui/react-scroll-area";
@@ -30,20 +33,36 @@ export const loader: LoaderFunction = async ({ request, params }) => {
 
 export default function Index() {
   const tags = useLoaderData<any[]>();
+  const location = useLocation();
+
+  console.log(`/${location.pathname.split("/").slice(1, 4).join("/")}`);
+
+  console.log("location", location.pathname);
+
+  tags.forEach((v) => {
+    v.to = `/${location.pathname.split("/").slice(1, 4).join("/")}/${v.name
+      .toLowerCase()
+      .replace(" ", "-")}`;
+  });
 
   return (
     <div className="space-y-1">
       <p className="text-2xl font-bold">Attachments</p>
-      <div>
+      <div className="flex">
         <ScrollArea.Root className="w-1/4 h-52">
           <ScrollArea.Viewport className="h-full w-full">
             {tags.map((v, i) => (
-              <div
-                key={i}
-                className="bg-slate-800 my-2 rounded text-lg p-2 hover:bg-slate-700"
-              >
-                {v.name}
-              </div>
+              <Link to={v.key} key={i}>
+                <div
+                  className={`my-2 rounded text-lg p-2 hover:bg-slate-800 ${
+                    location.pathname === v.to
+                      ? "bg-slate-800"
+                      : "bg-slate-700 "
+                  }`}
+                >
+                  {v.name}
+                </div>
+              </Link>
             ))}
           </ScrollArea.Viewport>
           <ScrollArea.Scrollbar
@@ -54,6 +73,9 @@ export default function Index() {
           </ScrollArea.Scrollbar>
           <ScrollArea.Corner className="bg-black-50" />
         </ScrollArea.Root>
+        <div className="w-3/4">
+          <Outlet context={{ tags }} />
+        </div>
       </div>
     </div>
   );

--- a/tournament-admin-v2/app/routes/participant.$id/route.tsx
+++ b/tournament-admin-v2/app/routes/participant.$id/route.tsx
@@ -56,6 +56,7 @@ export default function Participant() {
   });
 
   const mainPath = `/${location.pathname.split("/").slice(1, 3).join("/")}`;
+  const tabPath = `/${location.pathname.split("/").slice(1, 4).join("/")}`;
 
   const tabs = [
     { name: "Verification", to: `${mainPath}/verify` },
@@ -129,8 +130,7 @@ export default function Participant() {
               <Link to={tab.to} className="w-full">
                 <div
                   className={`w-full text-center border transition ease-in-out border-slate-100 rounded text-lg hover:bg-slate-500 ${
-                    tab.to === location.pathname &&
-                    "bg-slate-800 border-slate-300"
+                    tab.to === tabPath && "bg-slate-800 border-slate-300"
                   }`}
                 >
                   {tab.name}

--- a/tournament-admin-v2/package.json
+++ b/tournament-admin-v2/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-navigation-menu": "^1.1.4",
-    "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@remix-run/css-bundle": "^2.0.1",
     "@remix-run/node": "^2.0.1",
     "@remix-run/react": "^2.0.1",

--- a/tournament-admin-v2/yarn.lock
+++ b/tournament-admin-v2/yarn.lock
@@ -790,6 +790,13 @@
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@radix-ui/number@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.0.1.tgz#644161a3557f46ed38a042acf4a770e826021674"
+  integrity sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
 "@radix-ui/primitive@1.0.1":
   version "1.0.1"
   resolved "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz#e46f9958b35d10e9f6dc71c497305c22e3e55dbd"
@@ -887,21 +894,21 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-slot" "1.0.2"
 
-"@radix-ui/react-roving-focus@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz#e90c4a6a5f6ac09d3b8c1f5b5e81aab2f0db1974"
-  integrity sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==
+"@radix-ui/react-scroll-area@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.5.tgz#01160c6893f24a2ddb5aa399ae5b3ba84ad4d3cc"
+  integrity sha512-b6PAgH4GQf9QEn8zbT2XUHpW5z8BzqEc7Kl11TwDrvuTrxlkcjTD5qa/bxgKr+nmuXKu4L/W5UZ4mlP/VG/5Gw==
   dependencies:
     "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.1"
     "@radix-ui/primitive" "1.0.1"
-    "@radix-ui/react-collection" "1.0.3"
     "@radix-ui/react-compose-refs" "1.0.1"
     "@radix-ui/react-context" "1.0.1"
     "@radix-ui/react-direction" "1.0.1"
-    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-use-callback-ref" "1.0.1"
-    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
 
 "@radix-ui/react-slot@1.0.2":
   version "1.0.2"
@@ -910,21 +917,6 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.1"
-
-"@radix-ui/react-tabs@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz#993608eec55a5d1deddd446fa9978d2bc1053da2"
-  integrity sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@radix-ui/primitive" "1.0.1"
-    "@radix-ui/react-context" "1.0.1"
-    "@radix-ui/react-direction" "1.0.1"
-    "@radix-ui/react-id" "1.0.1"
-    "@radix-ui/react-presence" "1.0.1"
-    "@radix-ui/react-primitive" "1.0.3"
-    "@radix-ui/react-roving-focus" "1.0.4"
-    "@radix-ui/react-use-controllable-state" "1.0.1"
 
 "@radix-ui/react-use-callback-ref@1.0.1":
   version "1.0.1"

--- a/tournament-api/helpers/s3.ts
+++ b/tournament-api/helpers/s3.ts
@@ -74,11 +74,18 @@ export const getObjectByKey = async (key: string) => {
     Key: key,
   };
 
+  let type: string;
+  if (getExtensionByName(key) === "pdf") {
+    type = "application/pdf";
+  } else {
+    type = `image/${getExtensionByName(key)}`;
+  }
+
   try {
     const result = await s3Client.send(new GetObjectCommand(getParams));
     const imageArray = await result.Body.transformToByteArray();
     const imageStr = Buffer.from(imageArray).toString("base64");
-    const imageURl = `data:image/${getExtensionByName(key)};base64,${imageStr}`;
+    const imageURl = `data:${type};base64,${imageStr}`;
     return imageURl;
   } catch (err) {
     throw new Error("getObjectError");

--- a/tournament-api/routes/participants.ts
+++ b/tournament-api/routes/participants.ts
@@ -454,4 +454,25 @@ export const participantRoutes = (app: Express) => {
     });
     res.status(200).json(participant);
   });
+
+  app.get(
+    "/admin/participant/:id/attachments",
+    authenticateAdmin,
+    async (req, res) => {
+      const { id } = req.params;
+      const participantId = parseInt(id);
+      const participant = await prisma.participant.findUnique({
+        where: {
+          id: participantId,
+        },
+      });
+      // attachments for now will be photoId and waiver
+      const attachmentKeys = [
+        { name: "Photo ID", key: participant.photoIdKey },
+        { name: "Waiver", key: participant.waiverKey },
+      ];
+
+      return res.status(200).json(attachmentKeys);
+    }
+  );
 };


### PR DESCRIPTION
# Description of PR

closes #24 
creates an attachments section for the player view, allowing us to view photo ids and waivers

# How does it do this?

## Tournament API
- changed the way we construct the image URLs to infer type from extension (doesn't support anything but images and pdfs)

## Tournament Admin Dashboard
- created an attachments section that creates a list of our attachments and displays the correct view for them
